### PR TITLE
🛂 Add means to bypass Ego auth during local dev

### DIFF
--- a/src/config/globals.ts
+++ b/src/config/globals.ts
@@ -31,3 +31,4 @@ export const RDPC_POLICY_NAME = `${RDPC_DOMAIN}-${RDPC_REGION}`;
 export const MANAGEMENT_API = process.env.REACT_APP_MANAGEMENT_API || ``;
 export const MANAGEMENT_API_STATUS_URL = `${MANAGEMENT_API}/service-info`;
 export const RDPC_GATEWAY = process.env.REACT_APP_RDPC_GATEWAY || ``;
+export const IGNORE_EGO = process.env.REACT_APP_IGNORE_EGO;

--- a/src/providers/Auth.tsx
+++ b/src/providers/Auth.tsx
@@ -74,7 +74,11 @@ export const AuthProvider = ({ children }: any) => {
   };
 
   useEffect(() => {
-    configureEgoPublicKey();
+    if (process.env.REACT_APP_IGNORE_EGO) {
+      setLoading(false);
+    } else {
+      configureEgoPublicKey();
+    }
   }, []);
 
   return (
@@ -122,6 +126,10 @@ export const useAuth = () => {
   };
 
   const getEgoPublicKey = (): string => {
+    if (process.env.REACT_APP_IGNORE_EGO) {
+      return 'IGNORE_EGO=true';
+    }
+
     if (!egoPublicKey) {
       return '';
     }
@@ -138,6 +146,14 @@ export const useAuth = () => {
   };
 
   const getUserModel = () => {
+    if (process.env.REACT_APP_IGNORE_EGO) {
+      return {
+        firstName: 'Admin',
+        lastName: 'User',
+        email: 'admin@example.com',
+      };
+    }
+
     if (isValidJwt(getToken())) {
       const data = decodeToken(getToken());
       if (data && data.context && data.context.user) {
@@ -149,6 +165,10 @@ export const useAuth = () => {
   };
 
   const isLoggedIn = (): boolean => {
+    if (process.env.REACT_APP_IGNORE_EGO) {
+      return true;
+    }
+
     return isValidJwt(getToken());
   };
 
@@ -173,6 +193,10 @@ export const useAuth = () => {
   };
 
   const canWrite = (token?: string) => {
+    if (process.env.REACT_APP_IGNORE_EGO) {
+      return true;
+    }
+
     if (token) {
       return getPermissionsFromToken(token).filter(permission => permission.toLowerCase().startsWith(`${RDPC_POLICY_NAME}.WRITE`.toLowerCase())).length > 0;
     }
@@ -195,12 +219,10 @@ export const useAuth = () => {
     egoUtils(getEgoPublicKey()).isRdpcMember(permissions);
 
   return {
-    token: getToken(),
     setToken,
     clearToken,
     egoPublicKey: getEgoPublicKey(),
     loading,
-    permissions: getPermissions(),
     userModel: getUserModel(),
     isLoggedIn: isLoggedIn(),
     isValidJwt,

--- a/src/providers/Auth.tsx
+++ b/src/providers/Auth.tsx
@@ -20,7 +20,7 @@ import React, { useEffect, useContext, useState } from 'react';
 import egoUtils from '@icgc-argo/ego-token-utils';
 import memoize from 'lodash/memoize';
 import Cookies from 'js-cookie';
-import { EGO_JWT_KEY, EGO_PUBLIC_KEY_URL, RDPC_POLICY_NAME } from 'config/globals';
+import { EGO_JWT_KEY, EGO_PUBLIC_KEY_URL, RDPC_POLICY_NAME, IGNORE_EGO } from 'config/globals';
 
 type T_AuthContext = [
   [string, React.Dispatch<React.SetStateAction<string>>],
@@ -74,7 +74,7 @@ export const AuthProvider = ({ children }: any) => {
   };
 
   useEffect(() => {
-    if (process.env.REACT_APP_IGNORE_EGO) {
+    if (IGNORE_EGO) {
       setLoading(false);
     } else {
       configureEgoPublicKey();
@@ -126,7 +126,7 @@ export const useAuth = () => {
   };
 
   const getEgoPublicKey = (): string => {
-    if (process.env.REACT_APP_IGNORE_EGO) {
+    if (IGNORE_EGO) {
       return 'IGNORE_EGO=true';
     }
 
@@ -146,7 +146,7 @@ export const useAuth = () => {
   };
 
   const getUserModel = () => {
-    if (process.env.REACT_APP_IGNORE_EGO) {
+    if (IGNORE_EGO) {
       return {
         firstName: 'Admin',
         lastName: 'User',
@@ -165,7 +165,7 @@ export const useAuth = () => {
   };
 
   const isLoggedIn = (): boolean => {
-    if (process.env.REACT_APP_IGNORE_EGO) {
+    if (IGNORE_EGO) {
       return true;
     }
 
@@ -193,7 +193,7 @@ export const useAuth = () => {
   };
 
   const canWrite = (token?: string) => {
-    if (process.env.REACT_APP_IGNORE_EGO) {
+    if (IGNORE_EGO) {
       return true;
     }
 


### PR DESCRIPTION
In case you're ever having issues (or annoyances 😅 ) accessing Ego during local dev, start the app with
```
REACT_APP_IGNORE_EGO=true npm run start
```
to ignore Ego auth while the app is running.

This mocks out the `isLoggedIn` and `isAdmin` checks to be `true`, allowing you to quickly start or cancel runs without having to use Ego login every time.
--
🗑️  I also removed a couple properties that were being exposed by `useAuth` but never actually used: token and permissions. Anything related to the token or permissions is exposed through specific functions like `isLoggedIn` and `isAdmin` instead of looking at the whole token or permissions objects themselves.