### PR TITLE
🐛 Fix bug preventing error modals from showing (#101)

### DIFF
--- a/src/components/CancelRun.tsx
+++ b/src/components/CancelRun.tsx
@@ -70,7 +70,7 @@ export const CancelResponseModal = ({
   return (
     <ModalPortal>
       <Modal
-        title="Workflow Run Cancelled"
+        title={cancelResponse ? `Workflow Run Cancelled` : `Cancel Run Error`}
         actionVisible={false}
         onCancelClick={onCancelAcknowledge}
         cancelText="Ok"
@@ -95,7 +95,7 @@ export const CancelResponseModal = ({
                 padding: 0 10px;
               `}
             >
-              {cancelError instanceof ApolloError && (
+              {cancelError instanceof Error && (
                 <p>
                   <strong>Msg:</strong> {cancelError.message}
                 </p>

--- a/src/components/NewRunFormModal.tsx
+++ b/src/components/NewRunFormModal.tsx
@@ -99,10 +99,10 @@ export default ({
   return (
     <>
       <Button disabled={!isAdmin()} onClick={onNewRunClick}>new run</Button>
-      {runResponse && (
+      {(runResponse || runError) && (
         <ModalPortal>
           <Modal
-            title="Workflow Run Initiated"
+            title={`Workflow Run ${runResponse ? 'Initiated' : 'Error'}`}
             actionVisible={false}
             onCancelClick={onRunAcknowledge}
             cancelText="Ok"
@@ -127,7 +127,7 @@ export default ({
                     padding: 0 10px;
                   `}
                 >
-                  {runError instanceof ApolloError && (
+                  {runError instanceof Error && (
                     <p>
                       <strong>Msg:</strong> {runError.message}
                     </p>


### PR DESCRIPTION
* Display modal if runError exists after initiating a new run
* Check for instanceof parent class Error instead of child class ApolloError (to cover things like SyntaxError, etc)
* Change response modal title depending on success/error state